### PR TITLE
Liten typeskrift error endring i Linechart for å tillate buildstep me…

### DIFF
--- a/src/Components/LineChart.tsx
+++ b/src/Components/LineChart.tsx
@@ -180,7 +180,8 @@ const LineChartComponent: React.FC<LineChartComponentProps> = ({
 
   const plugin = {
     id: "customCanvasBackgroundColor",
-    beforeDraw: (chart, args, options) => {
+    // @ts-expect-error args any must be included for function to run.
+    beforeDraw: (chart: any, args: any, options: any) => {
       const { ctx } = chart;
       ctx.save();
       ctx.globalCompositeOperation = "destination-over";


### PR DESCRIPTION
…d plugin object

Plugin object krever et input parameter som blir injected i render, så skaper error i buildstep. Added ts-expect-error for å fikse buildstep.